### PR TITLE
Fix a glitch caused by invalid calling method on exporting tests

### DIFF
--- a/lib/kashi/client.rb
+++ b/lib/kashi/client.rb
@@ -138,7 +138,7 @@ module Kashi
       end
 
       # API access
-      tests = client.tests(method: :get)
+      tests = client.tests
       tests_by_id = tests.each_with_object({}) do |test, hash|
         # API access
         hash[test['TestID']] = client.tests_details(TestID: test['TestID'])


### PR DESCRIPTION
I encountered following error on exporting some tests.

```
[18:09:06]mozamimy@P861:tests (patch-moza) (-'x'-).oO(
(ins)> be kashi -e
I, [2018-01-05T18:09:28.024407 #50271]  INFO -- : Exporting...
bundler: failed to load command: kashi (/Users/mozamimy/.rbenv/versions/2.4/bin/kashi)
ArgumentError: wrong number of arguments (given 1, expected 0)
  /Users/mozamimy/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/kashi-0.1.1/lib/kashi/client_wrapper.rb:20:in `tests'
  /Users/mozamimy/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/kashi-0.1.1/lib/kashi/client.rb:141:in `export'
  /Users/mozamimy/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/kashi-0.1.1/lib/kashi/cli.rb:75:in `run'
  /Users/mozamimy/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/kashi-0.1.1/lib/kashi/cli.rb:28:in `run'
  /Users/mozamimy/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/kashi-0.1.1/lib/kashi/cli.rb:7:in `start'
  /Users/mozamimy/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/kashi-0.1.1/exe/kashi:4:in `<top (required)>'
  /Users/mozamimy/.rbenv/versions/2.4/bin/kashi:22:in `load'
  /Users/mozamimy/.rbenv/versions/2.4/bin/kashi:22:in `<top (required)>'
```

This error is caused by an illegal method calling at L.141 in lib/kashi/client.rb and I think it's valid to call `tests` method without any arguments.

@wata-gh Could you review this patch and merge if it's acceptable?